### PR TITLE
Explain execution steps in README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .Rproj.user
+.Rproj
 .Rhistory
 .RData
 .Ruserdata

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .Rproj.user
-.Rproj
 .Rhistory
 .RData
 .Ruserdata

--- a/README.md
+++ b/README.md
@@ -1,6 +1,42 @@
 # r2dii.physical.risk
-Functions, workflows and applications to estimate physical climate risk for physical assets and financial portfolios
+Functions, workflows and applications to estimate physical climate risk for physical assets and financial portfolios. 
 
-If input risk data is already prepared (found on DropBox at: `PortCheck/00_Data/01_ProcessedData/08_RiskData/climate_data`)
-Run `setup_project_specifications.R`
-Run `analysis.R`
+## Installation
+Clone this repo:
+``` bash
+git clone https://github.com/2DegreesInvesting/r2dii.physical.risk.git
+```
+
+All R package dependencies can easily be installed from the R console using:
+``` r
+# install.packages("devtools")
+devtools::install_deps(".")
+```
+
+## Default Input Data Paths
+
+## Running Analysis
+Preparing input data can be time consuming. Already prepared data can be found on DropBox at: `PortCheck/00_Data/01_ProcessedData/08_RiskData/climate_data`. To learn more about optionally preparing or updating this data, see the collapsible section "Preparing/ Updating Input Data" below. 
+
+Analysis can be run from the R console using: 
+``` r
+source("setup_project_specifications.R")
+source("analysis.R")
+```
+
+<details>
+  <summary>Optional: Preparing/ Updating Input Data</summary>
+  
+  ## Asset Resolution
+  `prepare_AR_data.R`
+  
+  ## Climate Data Factory
+  `prepare_CDF_data.R`
+  
+  ## Climate Analytics 
+  `prepare_climate_analytics_data.R`
+  
+  ## Open Street Map 
+  `prepare_OSM_data.R`
+
+</details>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # r2dii.physical.risk
 Functions, workflows and applications to estimate physical climate risk for physical assets and financial portfolios
+
+If input risk data is already prepared (found on DropBox at: `PortCheck/00_Data/01_ProcessedData/08_RiskData/climate_data`)
+Run `setup_project_specifications.R`
+Run `analysis.R`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # r2dii.physical.risk
-Functions, workflows and applications to estimate physical climate risk for physical assets and financial portfolios. 
+This repo contains functions, workflows and applications to estimate physical
+climate risk for physical assets and financial portfolios.
 
 ## Installation
-Clone this repo:
+First, clone this repo:
 ``` bash
 git clone https://github.com/2DegreesInvesting/r2dii.physical.risk.git
 ```
@@ -13,30 +14,89 @@ All R package dependencies can easily be installed from the R console using:
 devtools::install_deps(".")
 ```
 
-## Default Input Data Paths
+### Setting up Project Specifications
+Project specifications can be set in the file `setup_project_specifications.R`. 
+Things such as paths to input and output data directories are set in this file. 
+The physical risk module requires many different inputs and outputs. An example 
+full directory structure might look something like: 
+``` bash
+  Users                                                                  
+   °--Path                                                               
+       ¦--to                                                             
+       ¦   °--github                                                     
+       ¦       °--folder                                                 
+       ¦           °--r2dii.physical.risk  #path to this repo            
+       ¦               °--physical_risk                                  
+       °--Dropbox (2° Investing)                                         
+          ¦--PortCheck_v2                                                
+          ¦   °--10_Projects                                             
+          ¦       °--Some_Project                                        
+          ¦           °--06_Physical_Risk   #path to final output        
+          °--PortCheck                                                   
+              °--00_Data                                                 
+                  ¦--00_RawData                                          
+                  ¦   °--15_Risk                                         
+                  ¦       ¦--Climate Data Factory #raw CDF data          
+                  ¦       ¦   °--TCFD_Climate_Data-GeoTiff               
+                  ¦       ¦       °--GeoTIFF                             
+                  ¦       ¦           ¦--Indices                         
+                  ¦       ¦           °--Variables                       
+                  ¦       °--ClimateAnalytics #raw climate analytics data
+                  ¦--01_ProcessedData                                    
+                  ¦   °--08_RiskData                                     
+                  ¦       ¦--asset_level_data #processed asset-level data
+                  ¦       ¦   ¦--distinct_geo_data                       
+                  ¦       ¦   °--prepared_ald                            
+                  ¦       °--climate_data #processed climate risk data   
+                  ¦           ¦--CDF                                     
+                  ¦           °--WRI_data                                
+                  ¦--06_DataStore #datastore export                      
+                  ¦   °--DataStore_export_05172021                       
+                  ¦       °--2020Q4                                      
+                  °--07_AnalysisInputs #processed asset-level data       
+                      °--2019Q4_05172021_2021                            
+```
 
-## Running Analysis
-Preparing input data can be time consuming. Already prepared data can be found on DropBox at: `PortCheck/00_Data/01_ProcessedData/08_RiskData/climate_data`. To learn more about optionally preparing or updating this data, see the collapsible section "Preparing/ Updating Input Data" below. 
+It is very important that the output data folder locations are set properly in 
+the `setup_project_specifications.R` file (otherwise you risk over-writing 
+someone else's project). For example: 
 
-Analysis can be run from the R console using: 
+``` r
+# PACTA project path
+pacta_project <- "Some_Project"
+path_db_pacta_project <- fs::path(r2dii.utils::dbox_port2_10proj(), pacta_project)
+
+# ===============
+# set output paths
+# ===============
+
+# PACTA project output path
+path_db_pacta_project_pr_output <- fs::path(path_db_pacta_project, "06_Physical_Risk")
+```
+When you are happy with the specifications set in `setup_project_specifications`, you can source it from the R console:
 ``` r
 source("setup_project_specifications.R")
+```
+
+### Running Analysis
+Analysis can be run from the R console using:
+``` r
 source("analysis.R")
 ```
 
 <details>
   <summary>Optional: Preparing/ Updating Input Data</summary>
-  
+
   ## Asset Resolution
   `prepare_AR_data.R`
-  
+
   ## Climate Data Factory
   `prepare_CDF_data.R`
-  
-  ## Climate Analytics 
+
+  ## Climate Analytics
   `prepare_climate_analytics_data.R`
-  
-  ## Open Street Map 
+
+  ## Open Street Map
   `prepare_OSM_data.R`
 
 </details>


### PR DESCRIPTION
The README should concisely show which scripts need to be run, and in what order, to produce the desired output. 
It should also explain if external inputs are needed (ie. data from dropbox) and other setup steps that may not be immediately obvious to a new user. 