### PR TITLE
Remove unused paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,41 +20,33 @@ Things such as paths to input and output data directories are set in this file.
 The physical risk module requires many different inputs and outputs. An example 
 full directory structure might look something like: 
 ``` bash
-  Users                                                                  
-   °--Path                                                               
-       ¦--to                                                             
-       ¦   °--github                                                     
-       ¦       °--folder                                                 
-       ¦           °--r2dii.physical.risk  #path to this repo            
-       ¦               °--physical_risk                                  
-       °--Dropbox (2° Investing)                                         
-          ¦--PortCheck_v2                                                
-          ¦   °--10_Projects                                             
-          ¦       °--Some_Project                                        
-          ¦           °--06_Physical_Risk   #path to final output        
-          °--PortCheck                                                   
-              °--00_Data                                                 
-                  ¦--00_RawData                                          
-                  ¦   °--15_Risk                                         
-                  ¦       ¦--Climate Data Factory #raw CDF data          
-                  ¦       ¦   °--TCFD_Climate_Data-GeoTiff               
-                  ¦       ¦       °--GeoTIFF                             
-                  ¦       ¦           ¦--Indices                         
-                  ¦       ¦           °--Variables                       
-                  ¦       °--ClimateAnalytics #raw climate analytics data
-                  ¦--01_ProcessedData                                    
-                  ¦   °--08_RiskData                                     
-                  ¦       ¦--asset_level_data #processed asset-level data
-                  ¦       ¦   ¦--distinct_geo_data                       
-                  ¦       ¦   °--prepared_ald                            
-                  ¦       °--climate_data #processed climate risk data   
-                  ¦           ¦--CDF                                     
-                  ¦           °--WRI_data                                
-                  ¦--06_DataStore #datastore export                      
-                  ¦   °--DataStore_export_05172021                       
-                  ¦       °--2020Q4                                      
-                  °--07_AnalysisInputs #processed asset-level data       
-                      °--2019Q4_05172021_2021                            
+1  Users                                                    
+2   °--path_to                                              
+3       °--Dropbox                                          
+4           ¦--PortCheck_v2                                 
+5           ¦   °--10_Projects                              
+6           ¦       °--SomeProject                          
+7           ¦           °--60_Physical_Risk                 
+8           °--PortCheck                                    
+9               °--00_Data                                  
+10                  ¦--00_RawData                           
+11                  ¦   °--15_Risk                          
+12                  ¦       ¦--Climate Data Factory         
+13                  ¦       ¦   °--TCFD_Climate_Data-GeoTiff
+14                  ¦       ¦       °--GeoTIFF              
+15                  ¦       ¦           ¦--Indices          
+16                  ¦       ¦           °--Variables        
+17                  ¦       °--ClimateAnalytics             
+18                  ¦--01_ProcessedData                     
+19                  ¦   °--08_RiskData                      
+20                  ¦       ¦--asset_level_data             
+21                  ¦       ¦   ¦--distinct_geo_data        
+22                  ¦       ¦   °--prepared_ald             
+23                  ¦       °--climate_data                 
+24                  ¦           °--CDF                      
+25                  °--06_DataStore                         
+26                      °--DataStore_export_timestamp       
+27                          °--quarter                      
 ```
 
 It is very important that the output data folder locations are set properly in 

--- a/set_up_project_specifications.R
+++ b/set_up_project_specifications.R
@@ -22,20 +22,14 @@ path_db_pr_climate_data_CDF_raw_geotiff_indices <- fs::path(path_db_pr_climate_d
 path_db_pr_climate_data_CDF_raw_geotiff_variables <- fs::path(path_db_pr_climate_data_CDF_raw_geotiff, "Variables")
 ### Raw climate analytics data
 path_db_pr_climate_data_raw <- fs::path(path_db_pr_climate_data_raw, "ClimateAnalytics")
-### WRI climate data
-path_db_pr_climate_data_WRI <- fs::path(path_db_pr_climate_data, "WRI_data")
 ## ALD directory
 path_db_pr_ald <- fs::path(path_db_pr_parent, "asset_level_data")
 ### full ALD data
 path_db_pr_ald_prepared <- fs::path(path_db_pr_ald, "prepared_ald")
 ### OSM data
 path_db_pr_ald_distinct_geo_data <- fs::path(path_db_pr_ald, "distinct_geo_data")
-# Analysis Inputs Path
-path_db_analysis_inputs <- fs::path(r2dii.utils::dbox_port_00(), "07_AnalysisInputs", "2019Q4_05172021_2021")
 # data store path
 path_db_datastore_export <- fs::path(r2dii.utils::dbox_port_00(), "06_DataStore", "DataStore_export_05172021", "2020Q4")
-# Github Path
-path_gh_pr <- fs::path(here::here(), "physical_risk")
 
 # ===============
 # set project paths
@@ -58,7 +52,6 @@ create_db_pr_paths(
     path_db_pacta_project_pr_output
   )
 )
-
 
 # visualise folder structure
 show_folder_structure(path_pattern = "path_")


### PR DESCRIPTION
Some of the paths defined in `set_up_project_specifications.R` are unused. 

I have removed them for now for clarity, we can always add them back when we end up using those particular datasets. 